### PR TITLE
feat: infer db loaded enum value names

### DIFF
--- a/fastapi_forge/string_utils.py
+++ b/fastapi_forge/string_utils.py
@@ -24,3 +24,9 @@ def pluralize(s: str) -> str:
     if is_singular:
         return p.plural(s)
     return s
+
+
+def number_to_word(v: int | str) -> str:
+    words = p.number_to_words(v)
+    word: str = words[0] if isinstance(words, list) else words
+    return word.replace(" ", "_")

--- a/uv.lock
+++ b/uv.lock
@@ -264,7 +264,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-forge"
-version = "0.7.1.dev5+gb22700d.d20250421"
+version = "0.7.1.dev6+gb216c63.d20250421"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Sometimes an enum is missing name labels for values, and instead has the value as the name. Now integer names will be converted to their string word representation