### PR TITLE
fix: camel to snake

### DIFF
--- a/fastapi_forge/dtos.py
+++ b/fastapi_forge/dtos.py
@@ -75,7 +75,6 @@ class CustomEnum(_Base):
                 sqlalchemy_prefix=True,
                 python_type=enum_repr,
                 faker_field_value=enum_value_repr,
-                value=enum_value_repr,
                 test_value=enum_value_repr,
             ),
         )

--- a/fastapi_forge/string_utils.py
+++ b/fastapi_forge/string_utils.py
@@ -1,16 +1,15 @@
+import re
+
 import inflect
 
 p = inflect.engine()
 
 
-def _convert(s: str, separator: str) -> str:
-    return "".join([separator + c.lower() if c.isupper() else c for c in s]).lstrip(
-        separator,
-    )
-
-
-def camel_to_snake(s: str) -> str:
-    return _convert(s, "_")
+def camel_to_snake(s: str):
+    s = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
+    s = re.sub("__([A-Z])", r"_\1", s)
+    s = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s)
+    return s.lower()
 
 
 def snake_to_camel(s: str) -> str:

--- a/fastapi_forge/type_info_registry.py
+++ b/fastapi_forge/type_info_registry.py
@@ -11,13 +11,32 @@ EnumName = Annotated[str, Field(...)]
 
 @dataclass
 class TypeInfo:
+    """
+    Stores metadata about a database column type for testing and data generation.
+
+    This class contains information needed to:
+    - Generate SQLAlchemy column definitions
+    - Create appropriate Python values for the type
+    - Generate fake test data
+    - Define test assertions for the type
+
+    Attributes:
+        sqlalchemy_type: The SQLAlchemy type name (e.g., 'Integer', 'String')
+        sqlalchemy_prefix: Whether to prefix the `sqlalchemy_type` with 'sa.' or not.
+        python_type: The corresponding Python type name (e.g., 'int', 'str')
+        faker_field_value: The factory field value for this type (can be a Faker method)
+        test_value: Value to insert into models for post/patch tests.
+        test_func: A function to call with the `test_value`.
+        encapsulate_assert: Wraps the `test_value` value (e.g, UUID(test_value))
+
+    """
+
     sqlalchemy_type: str
     sqlalchemy_prefix: bool
     python_type: str
     faker_field_value: str | None = None
-    value: str | None = None
-    test_value: str | None = None
     test_func: str | None = None
+    test_value: str | None = None
     encapsulate_assert: str | None = None
 
 
@@ -75,7 +94,6 @@ registry.register(
         sqlalchemy_prefix=True,
         python_type="str",
         faker_field_value=faker_placeholder.format(placeholder='"text"'),
-        value="hello",
         test_value="'world'",
     ),
 )
@@ -90,7 +108,6 @@ registry.register(
         faker_field_value=faker_placeholder.format(
             placeholder='"pyfloat", positive=True, min_value=0.1, max_value=100'
         ),
-        value="1.0",
         test_value="2.0",
     ),
 )
@@ -102,7 +119,6 @@ registry.register(
         sqlalchemy_prefix=True,
         python_type="bool",
         faker_field_value=faker_placeholder.format(placeholder='"boolean"'),
-        value="True",
         test_value="False",
     ),
 )
@@ -114,7 +130,6 @@ registry.register(
         sqlalchemy_prefix=True,
         python_type="datetime",
         faker_field_value=faker_placeholder.format(placeholder='"date_time"'),
-        value="datetime.now(timezone.utc)",
         test_value="datetime.now(timezone.utc)",
         test_func=".isoformat()",
     ),
@@ -127,7 +142,6 @@ registry.register(
         sqlalchemy_prefix=True,
         python_type="UUID",
         faker_field_value="str(uuid4())",
-        value="str(uuid4())",
         test_value="str(uuid4())",
         encapsulate_assert="UUID",
     ),
@@ -140,7 +154,6 @@ registry.register(
         sqlalchemy_prefix=False,
         python_type="dict[str, Any]",
         faker_field_value="{}",
-        value="{}",
         test_value='{"another_key": 123}',
     ),
 )
@@ -152,7 +165,6 @@ registry.register(
         sqlalchemy_prefix=True,
         python_type="int",
         faker_field_value=faker_placeholder.format(placeholder='"random_int"'),
-        value="1",
         test_value="2",
     ),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 import pytest
 
-from fastapi_forge.type_info_registry import enum_registry
+from fastapi_forge.type_info_registry import TypeInfoRegistry, enum_registry
 
 
 @pytest.fixture(autouse=True)
 def clear_enum_registry() -> None:
     enum_registry.clear()
+
+
+@pytest.fixture
+def type_info_registry() -> TypeInfoRegistry:
+    return TypeInfoRegistry()

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from fastapi_forge import string_utils
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("HTTPMethod", "http_method"),
+        ("simpleTest", "simple_test"),
+        ("already_snake", "already_snake"),
+        ("", ""),
+        ("A", "a"),
+        ("a", "a"),
+        ("ALL_CAPS", "all_caps"),
+        ("CamelCase", "camel_case"),
+        ("camelCase", "camel_case"),
+        ("PascalCase", "pascal_case"),
+        ("MixedCaseString", "mixed_case_string"),
+        ("XML2JSON", "xml2_json"),
+        ("JSON2XML", "json2_xml"),
+        ("userID42", "user_id42"),
+        ("item2Buy", "item2_buy"),
+        ("HTTPServer", "http_server"),
+        ("RESTAPI", "restapi"),
+        ("JSONData", "json_data"),
+        ("XMLParser", "xml_parser"),
+        ("ABC123DEF456", "abc123_def456"),
+        ("GetHTTPResponseCode", "get_http_response_code"),
+        ("ProcessHTMLDocument", "process_html_document"),
+        ("ABCD", "abcd"),
+        ("ABCDEF", "abcdef"),
+        ("ABCdEF", "ab_cd_ef"),
+        ("_internalField", "_internal_field"),
+        ("__privateField", "__private_field"),
+        ("preserve_existing", "preserve_existing"),
+        ("mixed_Case_With_Underscores", "mixed_case_with_underscores"),
+    ],
+)
+def test_camel_to_snake(value: str, expected: str) -> None:
+    assert string_utils.camel_to_snake(value) == expected

--- a/tests/test_type_registry.py
+++ b/tests/test_type_registry.py
@@ -1,0 +1,98 @@
+import pytest
+
+from fastapi_forge.dtos import CustomEnum, CustomEnumValue
+from fastapi_forge.enums import FieldDataTypeEnum
+from fastapi_forge.type_info_registry import TypeInfo, TypeInfoRegistry, enum_registry
+
+##########################
+# TypeInfoRegistry tests #
+##########################
+
+
+def test_registry_operations(type_info_registry: TypeInfoRegistry) -> None:
+    type_info_registry.register(
+        FieldDataTypeEnum.STRING,
+        TypeInfo(
+            sqlalchemy_type="String",
+            sqlalchemy_prefix=True,
+            python_type="str",
+        ),
+    )
+    assert type_info_registry.get(FieldDataTypeEnum.STRING)
+    assert len(type_info_registry.all()) == 1
+
+    assert FieldDataTypeEnum.STRING in type_info_registry
+
+    type_info_registry.clear()
+    assert len(type_info_registry.all()) == 0
+
+    assert FieldDataTypeEnum.STRING not in type_info_registry
+
+
+def test_registry_get_not_found(type_info_registry: TypeInfoRegistry) -> None:
+    with pytest.raises(KeyError) as exc_info:
+        type_info_registry.get(FieldDataTypeEnum.BOOLEAN)
+
+    assert "Key 'Boolean' not found." in str(exc_info.value)
+
+
+def test_key_already_registered(type_info_registry: TypeInfoRegistry) -> None:
+    type_info_registry.register(
+        FieldDataTypeEnum.STRING,
+        TypeInfo(
+            sqlalchemy_type="String",
+            sqlalchemy_prefix=True,
+            python_type="str",
+        ),
+    )
+    with pytest.raises(KeyError) as exc_info:
+        type_info_registry.register(
+            FieldDataTypeEnum.STRING,
+            TypeInfo(
+                sqlalchemy_type="String",
+                sqlalchemy_prefix=True,
+                python_type="str",
+            ),
+        )
+    assert "TypeInfoRegistry: Key 'String' is already registered." in str(
+        exc_info.value
+    )
+
+
+##############################
+# EnumTypeInfoRegistry tests #
+##############################
+
+
+def test_custom_enum_register() -> None:
+    enum = CustomEnum(name="HTTPMethod")
+    assert enum.name in enum_registry
+    assert len(enum_registry.all()) == 1
+
+    type_info = enum_registry.get(enum.name)
+    assert type_info.sqlalchemy_type == 'Enum(enums.HTTPMethod, name="http_method")'
+    assert type_info.faker_field_value is None
+
+
+def test_custom_enum_register_w_values() -> None:
+    enum = CustomEnum(
+        name="HTTPMethod",
+        values=[
+            CustomEnumValue(name="GET", value="auto()"),
+            CustomEnumValue(name="POST", value="auto()"),
+        ],
+    )
+
+    type_info = enum_registry.get(enum.name)
+    assert type_info.sqlalchemy_type == 'Enum(enums.HTTPMethod, name="http_method")'
+    assert type_info.faker_field_value == "enums.HTTPMethod.GET"
+
+
+def test_duplicate_custom_enum() -> None:
+    CustomEnum(name="TEST")
+    with pytest.raises(KeyError) as exc_info:
+        CustomEnum(name="TEST")
+
+    assert "EnumTypeInfoRegistry: Key 'TEST' is already registered." in str(
+        exc_info.value
+    )


### PR DESCRIPTION
- before, values like "HTTPMethod" would be converted to "h_t_t_p_method".
- also added tests for type registries and string utils